### PR TITLE
Dependency updates for Radar 2.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <netbeans.api.version>RELEASE80</netbeans.api.version>
+        <netbeans.api.version>RELEASE802</netbeans.api.version>
     </properties>
 
     <repositories>
@@ -110,7 +110,7 @@
         <dependency>
             <groupId>org.codehaus.sonar.runner</groupId>
             <artifactId>sonar-runner-api</artifactId>
-            <version>2.3</version>
+            <version>2.4</version>
             <type>jar</type>
         </dependency>
         <dependency>
@@ -151,7 +151,7 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-model</artifactId>
-            <version>3.1.0</version>
+            <version>3.3.9</version>
         </dependency>
         <dependency>
             <groupId>org.swinglabs.swingx</groupId>
@@ -161,42 +161,42 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.10</version>
+            <version>4.12</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.2.4</version>
+            <version>2.6.2</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>1.9.5</version>
+            <version>1.10.19</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
-            <version>3.1.0</version>
+            <version>3.3.9</version>
             <type>jar</type>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.1</version>
+            <version>4.5.2</version>
             <type>jar</type>
         </dependency>
         <dependency>
             <groupId>org.netbeans.api</groupId>
             <artifactId>org-netbeans-modules-keyring</artifactId>
-            <version>RELEASE80</version>
+            <version>${netbeans.api.version}</version>
             <type>jar</type>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.9</version>
+            <version>1.10</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
         <dependency>
             <groupId>org.codehaus.sonar</groupId>
             <artifactId>sonar-ws-client</artifactId>
-            <version>3.7.4</version>
+            <version>4.3.3</version>
         </dependency>
         <dependency>
             <groupId>commons-httpclient</groupId>

--- a/src/main/java/qubexplorer/RadarIssue.java
+++ b/src/main/java/qubexplorer/RadarIssue.java
@@ -137,4 +137,14 @@ public class RadarIssue implements Issue{
         return new IssueLocation(issue.componentKey(), lineNumber);
     }
 
+    @Override
+    public Long componentId() {
+        return issue.componentId();
+    }
+
+    @Override
+    public String debt() {
+        return issue.debt();
+    }
+
 }

--- a/src/main/java/qubexplorer/runner/SonarRunnerIssue.java
+++ b/src/main/java/qubexplorer/runner/SonarRunnerIssue.java
@@ -158,4 +158,14 @@ public class SonarRunnerIssue implements Issue{
         return Collections.emptyList();
     }
 
+    @Override
+    public Long componentId() {
+        return 0L;
+    }
+
+    @Override
+    public String debt() {
+        return "";
+    }
+
 }


### PR DESCRIPTION
This is really just a update to the pom.xml to bring some of the dependencies up to date. Namely

netbeans.api.version 80 -> 802
sonar-runner-api 2.3 -> 2.4
maven-model 3.1.0 -> 3.3.9
jUnit 4.10 -> 4.12
gson 2.2.4 -> 2.6.2
mokito-core 1.9.5 -> 1.10.19
maven-core 3.1.0 -> 3.3.9
httpclient 4.5.1 -> 4.5.2
commons-codec 1.9 -> 1.10

The main piece of work, which I've put in a separate commit (in case of concerns of the above updates causing regression issues), is to update sonar-ws-client from 3.7.4 to 4.3.3

This requires a few code changes as org.sonar.wsclient.issue.Issue has a few new abstract methods.

4.3.3 was the most recent version of sonar-ws-client I could get to before hitting some blockers which would involve more substantial rewriting.

Beyond 4.3.3 org.sonar.wsclient.services.Rule becomes org.sonar.wsclient.rule.Rule and Rule.getKey() is now Rule.key(), Rule.getTitle() is now Rule.title and Rule.getDescription() is Rule.description(). However, there appear to be no longer any equivalent to setKey, setTitle or setDescription for Rule - it looks like these are set via a map in the constructor.